### PR TITLE
variadic func fix

### DIFF
--- a/libft/ft_printf.c
+++ b/libft/ft_printf.c
@@ -53,5 +53,6 @@ int	ft_printf(const char *format, ...)
 			count += write(1, &format[i], 1);
 		i++;
 	}
+	va_end(param);
 	return (count);
 }


### PR DESCRIPTION
Fixed: 
- Closed variadic function after use.

```
Checking libft/ft_printf.c ...
libft/ft_printf.c:56:16: error: va_list 'param' was opened but not closed by va_end(). [va_end_missing]
 return (count);
               ^
```